### PR TITLE
Fix unit tests and update API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,89 @@
+# API Documentation
+
+## Products
+
+### List products
+- **Method:** GET
+- **Route:** /api/products
+- **Response example:**
+```json
+[
+  {
+    "id": 1,
+    "description": "Item 1",
+    "price": "10.00",
+    "created_at": "2024-01-01T00:00:00.000000Z",
+    "updated_at": "2024-01-01T00:00:00.000000Z"
+  }
+]
+```
+
+### Create product
+- **Method:** POST
+- **Route:** /api/products
+- **Body fields:**
+  - `description` (required, string)
+  - `price` (required, decimal with two digits)
+- **Request example:**
+```json
+{
+  "description": "Sample",
+  "price": "9.99"
+}
+```
+- **Response example:**
+```json
+{
+  "id": 1,
+  "description": "Sample",
+  "price": "9.99",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z"
+}
+```
+
+### Show product
+- **Method:** GET
+- **Route:** /api/products/{id}
+- **Response example:**
+```json
+{
+  "id": 1,
+  "description": "Sample",
+  "price": "9.99",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z"
+}
+```
+
+### Update product
+- **Method:** PUT
+- **Route:** /api/products/{id}
+- **Body fields:**
+  - `description` (sometimes required, string)
+  - `price` (sometimes required, decimal with two digits)
+- **Request example:**
+```json
+{
+  "description": "Updated",
+  "price": "19.99"
+}
+```
+- **Response example:**
+```json
+{
+  "id": 1,
+  "description": "Updated",
+  "price": "19.99",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z"
+}
+```
+
+### Delete product
+- **Method:** DELETE
+- **Route:** /api/products/{id}
+- **Response example:**
+```json
+{}
+```

--- a/tests/Unit/ProductRepositoryTest.php
+++ b/tests/Unit/ProductRepositoryTest.php
@@ -13,17 +13,19 @@ class ProductRepositoryTest extends TestCase
 
     public function test_all_returns_all_products(): void
     {
-        $products = Product::factory()->count(3)->create();
+        foreach (range(1, 3) as $i) {
+            Product::create(['description' => "Product $i", 'price' => $i]);
+        }
 
         $repository = new ProductRepository();
         $result = $repository->all();
 
-        $this->assertCount($products->count(), $result);
+        $this->assertCount(3, $result);
     }
 
     public function test_create_stores_product(): void
     {
-        $data = Product::factory()->make()->toArray();
+        $data = ['description' => 'Create product', 'price' => 9.99];
 
         $repository = new ProductRepository();
         $product = $repository->create($data);
@@ -33,8 +35,8 @@ class ProductRepositoryTest extends TestCase
 
     public function test_update_modifies_product(): void
     {
-        $product = Product::factory()->create();
-        $data = Product::factory()->make()->toArray();
+        $product = Product::create(['description' => 'Old', 'price' => 5]);
+        $data = ['description' => 'Updated', 'price' => 6.5];
 
         $repository = new ProductRepository();
         $repository->update($product, $data);
@@ -44,7 +46,7 @@ class ProductRepositoryTest extends TestCase
 
     public function test_delete_removes_product(): void
     {
-        $product = Product::factory()->create();
+        $product = Product::create(['description' => 'Delete', 'price' => 3]);
 
         $repository = new ProductRepository();
         $repository->delete($product);

--- a/tests/Unit/ProductServiceTest.php
+++ b/tests/Unit/ProductServiceTest.php
@@ -45,7 +45,7 @@ class ProductServiceTest extends TestCase
     {
         $repository = Mockery::mock(ProductRepository::class);
         $service = new ProductService($repository);
-        $product = Product::factory()->make();
+        $product = new Product(['description' => 'Old', 'price' => 10]);
         $data = ['description' => 'New', 'price' => 20];
 
         $repository->shouldReceive('update')->with($product, $data)->once()->andReturn($product);
@@ -57,7 +57,7 @@ class ProductServiceTest extends TestCase
     {
         $repository = Mockery::mock(ProductRepository::class);
         $service = new ProductService($repository);
-        $product = Product::factory()->make();
+        $product = new Product(['description' => 'Delete', 'price' => 5]);
 
         $repository->shouldReceive('delete')->with($product)->once();
 

--- a/tests/Unit/StoreProductRequestTest.php
+++ b/tests/Unit/StoreProductRequestTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit;
 
 use App\Http\Requests\StoreProductRequest;
-use App\Models\Product;
 use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
@@ -14,7 +13,10 @@ class StoreProductRequestTest extends TestCase
         $request = new StoreProductRequest();
         $rules = $request->rules();
 
-        $data = Product::factory()->make()->toArray();
+        $data = [
+            'description' => 'Test description',
+            'price' => '10.00',
+        ];
         $validator = Validator::make($data, $rules);
 
         $this->assertTrue($validator->passes());

--- a/tests/Unit/UpdateProductRequestTest.php
+++ b/tests/Unit/UpdateProductRequestTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Unit;
 
 use App\Http\Requests\UpdateProductRequest;
-use App\Models\Product;
 use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
@@ -14,7 +13,10 @@ class UpdateProductRequestTest extends TestCase
         $request = new UpdateProductRequest();
         $rules = $request->rules();
 
-        $data = Product::factory()->make()->toArray();
+        $data = [
+            'description' => 'New description',
+            'price' => '15.00',
+        ];
         $validator = Validator::make($data, $rules);
 
         $this->assertTrue($validator->passes());


### PR DESCRIPTION
## Summary
- replace model factories in unit tests with direct instantiation
- add markdown API documentation for product endpoints

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842eed3d37483209e2e6dbdd5c6a0dd