### PR TITLE
Add Customer CRUD

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreCustomerRequest;
+use App\Http\Requests\UpdateCustomerRequest;
+use App\Models\Customer;
+use App\Services\CustomerService;
+use Illuminate\Http\JsonResponse;
+
+class CustomerController extends Controller
+{
+    public function __construct(private CustomerService $service)
+    {
+    }
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->service->all());
+    }
+
+    public function store(StoreCustomerRequest $request): JsonResponse
+    {
+        $customer = $this->service->create($request->validated());
+
+        return response()->json($customer, 201);
+    }
+
+    public function show(Customer $customer): JsonResponse
+    {
+        return response()->json($customer);
+    }
+
+    public function update(UpdateCustomerRequest $request, Customer $customer): JsonResponse
+    {
+        $customer = $this->service->update($customer, $request->validated());
+
+        return response()->json($customer);
+    }
+
+    public function destroy(Customer $customer): JsonResponse
+    {
+        $this->service->delete($customer);
+
+        return response()->json([], 204);
+    }
+}

--- a/app/Http/Requests/StoreCustomerRequest.php
+++ b/app/Http/Requests/StoreCustomerRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCustomerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'email' => ['nullable', 'email'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCustomerRequest.php
+++ b/app/Http/Requests/UpdateCustomerRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCustomerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string'],
+            'email' => ['sometimes', 'nullable', 'email'],
+        ];
+    }
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Customer extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+    ];
+}

--- a/app/Repositories/CustomerRepository.php
+++ b/app/Repositories/CustomerRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Collection;
+
+class CustomerRepository
+{
+    public function all(): Collection
+    {
+        return Customer::all();
+    }
+
+    public function create(array $data): Customer
+    {
+        return Customer::create($data);
+    }
+
+    public function update(Customer $customer, array $data): Customer
+    {
+        $customer->update($data);
+
+        return $customer;
+    }
+
+    public function delete(Customer $customer): void
+    {
+        $customer->delete();
+    }
+}

--- a/app/Services/CustomerService.php
+++ b/app/Services/CustomerService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Customer;
+use App\Repositories\CustomerRepository;
+use Illuminate\Database\Eloquent\Collection;
+
+class CustomerService
+{
+    public function __construct(private CustomerRepository $repository)
+    {
+    }
+
+    public function all(): Collection
+    {
+        return $this->repository->all();
+    }
+
+    public function create(array $data): Customer
+    {
+        return $this->repository->create($data);
+    }
+
+    public function update(Customer $customer, array $data): Customer
+    {
+        return $this->repository->update($customer, $data);
+    }
+
+    public function delete(Customer $customer): void
+    {
+        $this->repository->delete($customer);
+    }
+}

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Customer>
+ */
+class CustomerFactory extends Factory
+{
+    protected $model = Customer::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->safeEmail(),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000001_create_customers_table.php
+++ b/database/migrations/2024_01_01_000001_create_customers_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('customers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customers');
+    }
+};

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,3 +87,91 @@
 ```json
 {}
 ```
+
+## Customers
+
+### List customers
+- **Method:** GET
+- **Route:** /api/customers
+- **Response example:**
+```json
+[
+  {
+    "id": 1,
+    "name": "John Doe",
+    "email": "john@example.com",
+    "created_at": "2024-01-01T00:00:00.000000Z",
+    "updated_at": "2024-01-01T00:00:00.000000Z"
+  }
+]
+```
+
+### Create customer
+- **Method:** POST
+- **Route:** /api/customers
+- **Body fields:**
+  - `name` (required, string)
+  - `email` (nullable, email)
+- **Request example:**
+```json
+{
+  "name": "Sample",
+  "email": "sample@example.com"
+}
+```
+- **Response example:**
+```json
+{
+  "id": 1,
+  "name": "Sample",
+  "email": "sample@example.com",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z"
+}
+```
+
+### Show customer
+- **Method:** GET
+- **Route:** /api/customers/{id}
+- **Response example:**
+```json
+{
+  "id": 1,
+  "name": "Sample",
+  "email": "sample@example.com",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z"
+}
+```
+
+### Update customer
+- **Method:** PUT
+- **Route:** /api/customers/{id}
+- **Body fields:**
+  - `name` (sometimes required, string)
+  - `email` (sometimes nullable, email)
+- **Request example:**
+```json
+{
+  "name": "Updated",
+  "email": "updated@example.com"
+}
+```
+- **Response example:**
+```json
+{
+  "id": 1,
+  "name": "Updated",
+  "email": "updated@example.com",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z"
+}
+```
+
+### Delete customer
+- **Method:** DELETE
+- **Route:** /api/customers/{id}
+- **Response example:**
+```json
+{}
+```

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,3 +19,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::apiResource('products', \App\Http\Controllers\ProductController::class);
+Route::apiResource('customers', \App\Http\Controllers\CustomerController::class);

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CustomerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_customers(): void
+    {
+        Customer::factory()->count(2)->create();
+
+        $response = $this->getJson('/api/customers');
+
+        $response->assertOk()->assertJsonCount(2);
+    }
+
+    public function test_store_creates_customer(): void
+    {
+        $data = Customer::factory()->make()->toArray();
+
+        $response = $this->postJson('/api/customers', $data);
+
+        $response->assertCreated()->assertJsonFragment(['name' => $data['name']]);
+        $this->assertDatabaseHas('customers', ['name' => $data['name']]);
+    }
+
+    public function test_show_returns_customer(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $response = $this->getJson("/api/customers/{$customer->id}");
+
+        $response->assertOk()->assertJson(['id' => $customer->id, 'name' => $customer->name]);
+    }
+
+    public function test_update_modifies_customer(): void
+    {
+        $customer = Customer::factory()->create();
+        $data = Customer::factory()->make()->toArray();
+
+        $response = $this->putJson("/api/customers/{$customer->id}", $data);
+
+        $response->assertOk()->assertJsonFragment(['name' => $data['name']]);
+        $this->assertDatabaseHas('customers', ['id' => $customer->id, 'name' => $data['name']]);
+    }
+
+    public function test_destroy_deletes_customer(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $response = $this->deleteJson("/api/customers/{$customer->id}");
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('customers', ['id' => $customer->id]);
+    }
+}

--- a/tests/Unit/CustomerRepositoryTest.php
+++ b/tests/Unit/CustomerRepositoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Customer;
+use App\Repositories\CustomerRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CustomerRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_all_returns_all_customers(): void
+    {
+        foreach (range(1, 3) as $i) {
+            Customer::create(['name' => "Customer $i", 'email' => "c$i@example.com"]);
+        }
+
+        $repository = new CustomerRepository();
+        $result = $repository->all();
+
+        $this->assertCount(3, $result);
+    }
+
+    public function test_create_stores_customer(): void
+    {
+        $data = ['name' => 'Create customer', 'email' => 'create@example.com'];
+
+        $repository = new CustomerRepository();
+        $customer = $repository->create($data);
+
+        $this->assertDatabaseHas('customers', ['id' => $customer->id]);
+    }
+
+    public function test_update_modifies_customer(): void
+    {
+        $customer = Customer::create(['name' => 'Old', 'email' => 'old@example.com']);
+        $data = ['name' => 'Updated', 'email' => 'updated@example.com'];
+
+        $repository = new CustomerRepository();
+        $repository->update($customer, $data);
+
+        $this->assertDatabaseHas('customers', ['id' => $customer->id, 'name' => $data['name']]);
+    }
+
+    public function test_delete_removes_customer(): void
+    {
+        $customer = Customer::create(['name' => 'Delete', 'email' => 'del@example.com']);
+
+        $repository = new CustomerRepository();
+        $repository->delete($customer);
+
+        $this->assertDatabaseMissing('customers', ['id' => $customer->id]);
+    }
+}

--- a/tests/Unit/CustomerServiceTest.php
+++ b/tests/Unit/CustomerServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Customer;
+use App\Repositories\CustomerRepository;
+use App\Services\CustomerService;
+use Illuminate\Database\Eloquent\Collection;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class CustomerServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_all_returns_customers(): void
+    {
+        $repository = Mockery::mock(CustomerRepository::class);
+        $service = new CustomerService($repository);
+        $collection = new Collection([new Customer(), new Customer()]);
+
+        $repository->shouldReceive('all')->once()->andReturn($collection);
+
+        $this->assertSame($collection, $service->all());
+    }
+
+    public function test_create_calls_repository(): void
+    {
+        $repository = Mockery::mock(CustomerRepository::class);
+        $service = new CustomerService($repository);
+        $data = ['name' => 'Test', 'email' => 'test@example.com'];
+        $customer = new Customer($data);
+
+        $repository->shouldReceive('create')->with($data)->once()->andReturn($customer);
+
+        $this->assertSame($customer, $service->create($data));
+    }
+
+    public function test_update_calls_repository(): void
+    {
+        $repository = Mockery::mock(CustomerRepository::class);
+        $service = new CustomerService($repository);
+        $customer = new Customer(['name' => 'Old', 'email' => 'old@example.com']);
+        $data = ['name' => 'New', 'email' => 'new@example.com'];
+
+        $repository->shouldReceive('update')->with($customer, $data)->once()->andReturn($customer);
+
+        $this->assertSame($customer, $service->update($customer, $data));
+    }
+
+    public function test_delete_calls_repository(): void
+    {
+        $repository = Mockery::mock(CustomerRepository::class);
+        $service = new CustomerService($repository);
+        $customer = new Customer(['name' => 'Delete', 'email' => 'd@example.com']);
+
+        $repository->shouldReceive('delete')->with($customer)->once();
+
+        $service->delete($customer);
+    }
+}

--- a/tests/Unit/StoreCustomerRequestTest.php
+++ b/tests/Unit/StoreCustomerRequestTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Requests\StoreCustomerRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class StoreCustomerRequestTest extends TestCase
+{
+    public function test_rules_validate_data(): void
+    {
+        $request = new StoreCustomerRequest();
+        $rules = $request->rules();
+
+        $data = [
+            'name' => 'Customer',
+            'email' => 'c@example.com',
+        ];
+        $validator = Validator::make($data, $rules);
+
+        $this->assertTrue($validator->passes());
+    }
+}

--- a/tests/Unit/UpdateCustomerRequestTest.php
+++ b/tests/Unit/UpdateCustomerRequestTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Requests\UpdateCustomerRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class UpdateCustomerRequestTest extends TestCase
+{
+    public function test_rules_validate_data(): void
+    {
+        $request = new UpdateCustomerRequest();
+        $rules = $request->rules();
+
+        $data = [
+            'name' => 'Updated',
+            'email' => 'u@example.com',
+        ];
+        $validator = Validator::make($data, $rules);
+
+        $this->assertTrue($validator->passes());
+    }
+}


### PR DESCRIPTION
## Summary
- add migration, model, repository, service and controller for Customer
- create request validation classes
- register Customer API routes
- add factories and comprehensive tests
- update API documentation with customer endpoints

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1d4a5708320a26e01a0d8f82eaa