### PR TITLE
Add sale CRUD

### DIFF
--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreSaleRequest;
+use App\Http\Requests\UpdateSaleRequest;
+use App\Models\Sale;
+use App\Services\SaleService;
+use Illuminate\Http\JsonResponse;
+
+class SaleController extends Controller
+{
+    public function __construct(private SaleService $service)
+    {
+    }
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->service->all());
+    }
+
+    public function store(StoreSaleRequest $request): JsonResponse
+    {
+        $sale = $this->service->create($request->validated());
+
+        return response()->json($sale, 201);
+    }
+
+    public function show(Sale $sale): JsonResponse
+    {
+        return response()->json($sale->load('saleProducts'));
+    }
+
+    public function update(UpdateSaleRequest $request, Sale $sale): JsonResponse
+    {
+        $sale = $this->service->update($sale, $request->validated());
+
+        return response()->json($sale);
+    }
+
+    public function destroy(Sale $sale): JsonResponse
+    {
+        $this->service->delete($sale);
+
+        return response()->json([], 204);
+    }
+}

--- a/app/Http/Requests/StoreSaleRequest.php
+++ b/app/Http/Requests/StoreSaleRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSaleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'date' => ['required', 'date'],
+            'customer_id' => ['required', 'exists:customers,id'],
+            'products' => ['required', 'array', 'min:1'],
+            'products.*.product_id' => ['required', 'exists:products,id'],
+            'products.*.quantity' => ['required', 'integer', 'min:1'],
+            'products.*.price' => ['required', 'regex:/^\d+(\.\d{1,2})?$/'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateSaleRequest.php
+++ b/app/Http/Requests/UpdateSaleRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSaleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'date' => ['sometimes', 'required', 'date'],
+            'customer_id' => ['sometimes', 'required', 'exists:customers,id'],
+            'products' => ['sometimes', 'required', 'array', 'min:1'],
+            'products.*.product_id' => ['required_with:products', 'exists:products,id'],
+            'products.*.quantity' => ['required_with:products', 'integer', 'min:1'],
+            'products.*.price' => ['required_with:products', 'regex:/^\d+(\.\d{1,2})?$/'],
+        ];
+    }
+}

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Sale extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'date',
+        'customer_id',
+        'total',
+    ];
+
+    public function saleProducts()
+    {
+        return $this->hasMany(SaleProduct::class);
+    }
+
+    public function customer()
+    {
+        return $this->belongsTo(Customer::class);
+    }
+}

--- a/app/Models/SaleProduct.php
+++ b/app/Models/SaleProduct.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SaleProduct extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'sale_id',
+        'product_id',
+        'quantity',
+        'price',
+    ];
+
+    public function sale()
+    {
+        return $this->belongsTo(Sale::class);
+    }
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Repositories/SaleRepository.php
+++ b/app/Repositories/SaleRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Sale;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+
+class SaleRepository
+{
+    public function all(): Collection
+    {
+        return Sale::with('saleProducts')->get();
+    }
+
+    public function create(array $data): Sale
+    {
+        return DB::transaction(function () use ($data) {
+            $products = $data['products'];
+            unset($data['products']);
+            $sale = Sale::create($data);
+            $total = 0;
+            foreach ($products as $product) {
+                $sale->saleProducts()->create($product);
+                $total += $product['price'] * $product['quantity'];
+            }
+            $sale->update(['total' => $total]);
+            return $sale->load('saleProducts');
+        });
+    }
+
+    public function update(Sale $sale, array $data): Sale
+    {
+        return DB::transaction(function () use ($sale, $data) {
+            if (isset($data['date'])) {
+                $sale->date = $data['date'];
+            }
+            if (isset($data['customer_id'])) {
+                $sale->customer_id = $data['customer_id'];
+            }
+            $sale->save();
+            if (isset($data['products'])) {
+                $sale->saleProducts()->delete();
+                $total = 0;
+                foreach ($data['products'] as $product) {
+                    $sale->saleProducts()->create($product);
+                    $total += $product['price'] * $product['quantity'];
+                }
+                $sale->update(['total' => $total]);
+            }
+            return $sale->load('saleProducts');
+        });
+    }
+
+    public function delete(Sale $sale): void
+    {
+        DB::transaction(function () use ($sale) {
+            $sale->saleProducts()->delete();
+            $sale->delete();
+        });
+    }
+}

--- a/app/Services/SaleService.php
+++ b/app/Services/SaleService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Sale;
+use App\Repositories\SaleRepository;
+use Illuminate\Database\Eloquent\Collection;
+
+class SaleService
+{
+    public function __construct(private SaleRepository $repository)
+    {
+    }
+
+    public function all(): Collection
+    {
+        return $this->repository->all();
+    }
+
+    public function create(array $data): Sale
+    {
+        return $this->repository->create($data);
+    }
+
+    public function update(Sale $sale, array $data): Sale
+    {
+        return $this->repository->update($sale, $data);
+    }
+
+    public function delete(Sale $sale): void
+    {
+        $this->repository->delete($sale);
+    }
+}

--- a/database/migrations/2024_01_01_000002_create_sales_table.php
+++ b/database/migrations/2024_01_01_000002_create_sales_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sales', function (Blueprint $table) {
+            $table->id();
+            $table->date('date');
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->decimal('total', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sales');
+    }
+};

--- a/database/migrations/2024_01_01_000003_create_sale_products_table.php
+++ b/database/migrations/2024_01_01_000003_create_sale_products_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sale_products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sale_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->integer('quantity');
+            $table->decimal('price', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sale_products');
+    }
+};

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,3 +175,152 @@
 ```json
 {}
 ```
+
+## Sales
+
+### List sales
+- **Method:** GET
+- **Route:** /api/sales
+- **Response example:**
+```json
+[
+  {
+    "id": 1,
+    "date": "2024-01-01",
+    "customer_id": 1,
+    "total": "10.00",
+    "created_at": "2024-01-01T00:00:00.000000Z",
+    "updated_at": "2024-01-01T00:00:00.000000Z",
+    "sale_products": [
+      {
+        "id": 1,
+        "sale_id": 1,
+        "product_id": 1,
+        "quantity": 1,
+        "price": "10.00",
+        "created_at": "2024-01-01T00:00:00.000000Z",
+        "updated_at": "2024-01-01T00:00:00.000000Z"
+      }
+    ]
+  }
+]
+```
+
+### Create sale
+- **Method:** POST
+- **Route:** /api/sales
+- **Body fields:**
+  - `date` (required, date)
+  - `customer_id` (required, integer)
+  - `products` (required, array of objects)
+  - `products.*.product_id` (required, integer)
+  - `products.*.quantity` (required, integer)
+  - `products.*.price` (required, decimal with two digits)
+- **Request example:**
+```json
+{
+  "date": "2024-01-01",
+  "customer_id": 1,
+  "products": [
+    {"product_id": 1, "quantity": 2, "price": "10.00"}
+  ]
+}
+```
+- **Response example:**
+```json
+{
+  "id": 1,
+  "date": "2024-01-01",
+  "customer_id": 1,
+  "total": "20.00",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z",
+  "sale_products": [
+    {
+      "id": 1,
+      "sale_id": 1,
+      "product_id": 1,
+      "quantity": 2,
+      "price": "10.00",
+      "created_at": "2024-01-01T00:00:00.000000Z",
+      "updated_at": "2024-01-01T00:00:00.000000Z"
+    }
+  ]
+}
+```
+
+### Show sale
+- **Method:** GET
+- **Route:** /api/sales/{id}
+- **Response example:**
+```json
+{
+  "id": 1,
+  "date": "2024-01-01",
+  "customer_id": 1,
+  "total": "20.00",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z",
+  "sale_products": [
+    {
+      "id": 1,
+      "sale_id": 1,
+      "product_id": 1,
+      "quantity": 2,
+      "price": "10.00",
+      "created_at": "2024-01-01T00:00:00.000000Z",
+      "updated_at": "2024-01-01T00:00:00.000000Z"
+    }
+  ]
+}
+```
+
+### Update sale
+- **Method:** PUT
+- **Route:** /api/sales/{id}
+- **Body fields:**
+  - `date` (sometimes required, date)
+  - `customer_id` (sometimes required, integer)
+  - `products` (sometimes required, array of objects)
+  - `products.*.product_id` (required when products present, integer)
+  - `products.*.quantity` (required when products present, integer)
+  - `products.*.price` (required when products present, decimal with two digits)
+- **Request example:**
+```json
+{
+  "date": "2024-01-02",
+  "products": [
+    {"product_id": 1, "quantity": 1, "price": "5.00"}
+  ]
+}
+```
+- **Response example:**
+```json
+{
+  "id": 1,
+  "date": "2024-01-02",
+  "customer_id": 1,
+  "total": "5.00",
+  "created_at": "2024-01-01T00:00:00.000000Z",
+  "updated_at": "2024-01-01T00:00:00.000000Z",
+  "sale_products": [
+    {
+      "id": 1,
+      "sale_id": 1,
+      "product_id": 1,
+      "quantity": 1,
+      "price": "5.00",
+      "created_at": "2024-01-01T00:00:00.000000Z",
+      "updated_at": "2024-01-01T00:00:00.000000Z"
+    }
+  ]
+}
+```
+
+### Delete sale
+- **Method:** DELETE
+- **Route:** /api/sales/{id}
+- **Response example:**
+```json
+{}
+```

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,3 +20,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 Route::apiResource('products', \App\Http\Controllers\ProductController::class);
 Route::apiResource('customers', \App\Http\Controllers\CustomerController::class);
+Route::apiResource('sales', \App\Http\Controllers\SaleController::class);

--- a/tests/Feature/SaleTest.php
+++ b/tests/Feature/SaleTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\Product;
+use App\Services\SaleService;
+use App\Repositories\SaleRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SaleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createSale(): void
+    {
+        $service = new SaleService(new SaleRepository());
+        $customer = Customer::factory()->create();
+        $product = Product::factory()->create();
+        $service->create([
+            'date' => now()->toDateString(),
+            'customer_id' => $customer->id,
+            'products' => [
+                ['product_id' => $product->id, 'quantity' => 1, 'price' => $product->price],
+            ],
+        ]);
+    }
+
+    public function test_index_returns_sales(): void
+    {
+        $this->createSale();
+
+        $response = $this->getJson('/api/sales');
+
+        $response->assertOk()->assertJsonCount(1);
+    }
+
+    public function test_store_creates_sale(): void
+    {
+        $customer = Customer::factory()->create();
+        $product = Product::factory()->create();
+        $data = [
+            'date' => now()->toDateString(),
+            'customer_id' => $customer->id,
+            'products' => [
+                ['product_id' => $product->id, 'quantity' => 2, 'price' => $product->price],
+            ],
+        ];
+
+        $response = $this->postJson('/api/sales', $data);
+
+        $response->assertCreated()->assertJsonFragment(['customer_id' => $customer->id]);
+        $this->assertDatabaseHas('sales', ['id' => $response->json('id'), 'total' => $product->price * 2]);
+        $this->assertDatabaseHas('sale_products', ['sale_id' => $response->json('id'), 'product_id' => $product->id]);
+    }
+
+    public function test_show_returns_sale(): void
+    {
+        $this->createSale();
+        $saleId = 1;
+
+        $response = $this->getJson("/api/sales/{$saleId}");
+
+        $response->assertOk()->assertJson(['id' => $saleId]);
+    }
+
+    public function test_update_modifies_sale(): void
+    {
+        $service = new SaleService(new SaleRepository());
+        $customer = Customer::factory()->create();
+        $product = Product::factory()->create();
+        $sale = $service->create([
+            'date' => now()->toDateString(),
+            'customer_id' => $customer->id,
+            'products' => [
+                ['product_id' => $product->id, 'quantity' => 1, 'price' => $product->price],
+            ],
+        ]);
+        $newProduct = Product::factory()->create();
+        $data = [
+            'date' => now()->addDay()->toDateString(),
+            'products' => [
+                ['product_id' => $newProduct->id, 'quantity' => 3, 'price' => $newProduct->price],
+            ],
+        ];
+
+        $response = $this->putJson("/api/sales/{$sale->id}", $data);
+
+        $response->assertOk()->assertJsonFragment(['total' => $newProduct->price * 3]);
+        $this->assertDatabaseHas('sale_products', ['sale_id' => $sale->id, 'product_id' => $newProduct->id]);
+    }
+
+    public function test_destroy_deletes_sale(): void
+    {
+        $service = new SaleService(new SaleRepository());
+        $customer = Customer::factory()->create();
+        $product = Product::factory()->create();
+        $sale = $service->create([
+            'date' => now()->toDateString(),
+            'customer_id' => $customer->id,
+            'products' => [
+                ['product_id' => $product->id, 'quantity' => 1, 'price' => $product->price],
+            ],
+        ]);
+
+        $response = $this->deleteJson("/api/sales/{$sale->id}");
+
+        $response->assertNoContent();
+        $this->assertDatabaseMissing('sales', ['id' => $sale->id]);
+    }
+}

--- a/tests/Unit/SaleRepositoryTest.php
+++ b/tests/Unit/SaleRepositoryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\Sale;
+use App\Repositories\SaleRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SaleRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_all_returns_all_sales(): void
+    {
+        $customer = Customer::factory()->create();
+        $product = Product::factory()->create();
+        $repository = new SaleRepository();
+        $repository->create([
+            'date' => '2024-01-01',
+            'customer_id' => $customer->id,
+            'products' => [
+                ['product_id' => $product->id, 'quantity' => 1, 'price' => $product->price],
+            ],
+        ]);
+
+        $result = $repository->all();
+
+        $this->assertCount(1, $result);
+    }
+
+    public function test_create_stores_sale(): void
+    {
+        $customer = Customer::factory()->create();
+        $product = Product::factory()->create();
+        $repository = new SaleRepository();
+        $sale = $repository->create([
+            'date' => '2024-01-01',
+            'customer_id' => $customer->id,
+            'products' => [
+                ['product_id' => $product->id, 'quantity' => 2, 'price' => $product->price],
+            ],
+        ]);
+
+        $this->assertDatabaseHas('sales', ['id' => $sale->id, 'total' => $product->price * 2]);
+    }
+
+    public function test_update_modifies_sale(): void
+    {
+        $customer = Customer::factory()->create();
+        $product = Product::factory()->create();
+        $repository = new SaleRepository();
+        $sale = $repository->create([
+            'date' => '2024-01-01',
+            'customer_id' => $customer->id,
+            'products' => [
+                ['product_id' => $product->id, 'quantity' => 1, 'price' => $product->price],
+            ],
+        ]);
+        $newProduct = Product::factory()->create();
+        $repository->update($sale, [
+            'products' => [
+                ['product_id' => $newProduct->id, 'quantity' => 3, 'price' => $newProduct->price],
+            ],
+        ]);
+
+        $this->assertDatabaseHas('sale_products', ['sale_id' => $sale->id, 'product_id' => $newProduct->id]);
+    }
+
+    public function test_delete_removes_sale(): void
+    {
+        $customer = Customer::factory()->create();
+        $product = Product::factory()->create();
+        $repository = new SaleRepository();
+        $sale = $repository->create([
+            'date' => '2024-01-01',
+            'customer_id' => $customer->id,
+            'products' => [
+                ['product_id' => $product->id, 'quantity' => 1, 'price' => $product->price],
+            ],
+        ]);
+        $repository->delete($sale);
+
+        $this->assertDatabaseMissing('sales', ['id' => $sale->id]);
+    }
+}

--- a/tests/Unit/SaleServiceTest.php
+++ b/tests/Unit/SaleServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Sale;
+use App\Repositories\SaleRepository;
+use App\Services\SaleService;
+use Illuminate\Database\Eloquent\Collection;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class SaleServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_all_returns_sales(): void
+    {
+        $repository = Mockery::mock(SaleRepository::class);
+        $service = new SaleService($repository);
+        $collection = new Collection([new Sale(), new Sale()]);
+        $repository->shouldReceive('all')->once()->andReturn($collection);
+        $this->assertSame($collection, $service->all());
+    }
+
+    public function test_create_calls_repository(): void
+    {
+        $repository = Mockery::mock(SaleRepository::class);
+        $service = new SaleService($repository);
+        $data = ['date' => '2024-01-01'];
+        $sale = new Sale($data);
+        $repository->shouldReceive('create')->with($data)->once()->andReturn($sale);
+        $this->assertSame($sale, $service->create($data));
+    }
+
+    public function test_update_calls_repository(): void
+    {
+        $repository = Mockery::mock(SaleRepository::class);
+        $service = new SaleService($repository);
+        $sale = new Sale(['date' => '2024-01-01']);
+        $data = ['date' => '2024-01-02'];
+        $repository->shouldReceive('update')->with($sale, $data)->once()->andReturn($sale);
+        $this->assertSame($sale, $service->update($sale, $data));
+    }
+
+    public function test_delete_calls_repository(): void
+    {
+        $repository = Mockery::mock(SaleRepository::class);
+        $service = new SaleService($repository);
+        $sale = new Sale(['date' => '2024-01-01']);
+        $repository->shouldReceive('delete')->with($sale)->once();
+        $service->delete($sale);
+    }
+}

--- a/tests/Unit/StoreSaleRequestTest.php
+++ b/tests/Unit/StoreSaleRequestTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Requests\StoreSaleRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class StoreSaleRequestTest extends TestCase
+{
+    public function test_rules_validate_data(): void
+    {
+        $request = new StoreSaleRequest();
+        $rules = $request->rules();
+        $data = [
+            'date' => '2024-01-01',
+            'customer_id' => 1,
+            'products' => [
+                ['product_id' => 1, 'quantity' => 1, 'price' => '10.00'],
+            ],
+        ];
+        $validator = Validator::make($data, $rules);
+        $this->assertTrue($validator->passes());
+    }
+}

--- a/tests/Unit/UpdateSaleRequestTest.php
+++ b/tests/Unit/UpdateSaleRequestTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Requests\UpdateSaleRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class UpdateSaleRequestTest extends TestCase
+{
+    public function test_rules_validate_data(): void
+    {
+        $request = new UpdateSaleRequest();
+        $rules = $request->rules();
+        $data = [
+            'date' => '2024-01-02',
+            'customer_id' => 1,
+            'products' => [
+                ['product_id' => 1, 'quantity' => 2, 'price' => '20.00'],
+            ],
+        ];
+        $validator = Validator::make($data, $rules);
+        $this->assertTrue($validator->passes());
+    }
+}


### PR DESCRIPTION
## Summary
- add migrations for sales and sale_products
- implement Sale model, repository, service and controller
- create requests for sale creation and update
- register sales routes
- document sales API endpoints
- add unit and feature tests

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843019a1d4083209887955ec1bc119c