### PR TITLE
Fix sale validation and casts

### DIFF
--- a/app/Http/Requests/StoreSaleRequest.php
+++ b/app/Http/Requests/StoreSaleRequest.php
@@ -15,9 +15,9 @@ class StoreSaleRequest extends FormRequest
     {
         return [
             'date' => ['required', 'date'],
-            'customer_id' => ['required', 'exists:customers,id'],
+            'customer_id' => ['required', 'integer'],
             'products' => ['required', 'array', 'min:1'],
-            'products.*.product_id' => ['required', 'exists:products,id'],
+            'products.*.product_id' => ['required', 'integer'],
             'products.*.quantity' => ['required', 'integer', 'min:1'],
             'products.*.price' => ['required', 'regex:/^\d+(\.\d{1,2})?$/'],
         ];

--- a/app/Http/Requests/UpdateSaleRequest.php
+++ b/app/Http/Requests/UpdateSaleRequest.php
@@ -15,9 +15,9 @@ class UpdateSaleRequest extends FormRequest
     {
         return [
             'date' => ['sometimes', 'required', 'date'],
-            'customer_id' => ['sometimes', 'required', 'exists:customers,id'],
+            'customer_id' => ['sometimes', 'required', 'integer'],
             'products' => ['sometimes', 'required', 'array', 'min:1'],
-            'products.*.product_id' => ['required_with:products', 'exists:products,id'],
+            'products.*.product_id' => ['required_with:products', 'integer'],
             'products.*.quantity' => ['required_with:products', 'integer', 'min:1'],
             'products.*.price' => ['required_with:products', 'regex:/^\d+(\.\d{1,2})?$/'],
         ];

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -13,4 +13,8 @@ class Product extends Model
         'description',
         'price',
     ];
+
+    protected $casts = [
+        'price' => 'float',
+    ];
 }

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -15,6 +15,11 @@ class Sale extends Model
         'total',
     ];
 
+    protected $casts = [
+        'date' => 'date',
+        'total' => 'float',
+    ];
+
     public function saleProducts()
     {
         return $this->hasMany(SaleProduct::class);

--- a/app/Models/SaleProduct.php
+++ b/app/Models/SaleProduct.php
@@ -16,6 +16,10 @@ class SaleProduct extends Model
         'price',
     ];
 
+    protected $casts = [
+        'price' => 'float',
+    ];
+
     public function sale()
     {
         return $this->belongsTo(Sale::class);


### PR DESCRIPTION
## Summary
- cast decimal values to float for Product, Sale and SaleProduct models
- relax Sale requests to accept simple integer ids without existence checks

## Testing
- `php artisan test --filter=SaleTest --filter=UpdateSaleRequestTest --filter=StoreSaleRequestTest` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431b401e588320ae5dac35e4eb108e