### PR TITLE
Fix service tests using application base

### DIFF
--- a/tests/Unit/CustomerServiceTest.php
+++ b/tests/Unit/CustomerServiceTest.php
@@ -7,7 +7,7 @@ use App\Repositories\CustomerRepository;
 use App\Services\CustomerService;
 use Illuminate\Database\Eloquent\Collection;
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class CustomerServiceTest extends TestCase
 {

--- a/tests/Unit/ProductServiceTest.php
+++ b/tests/Unit/ProductServiceTest.php
@@ -7,7 +7,7 @@ use App\Repositories\ProductRepository;
 use App\Services\ProductService;
 use Illuminate\Database\Eloquent\Collection;
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class ProductServiceTest extends TestCase
 {

--- a/tests/Unit/SaleServiceTest.php
+++ b/tests/Unit/SaleServiceTest.php
@@ -7,7 +7,7 @@ use App\Repositories\SaleRepository;
 use App\Services\SaleService;
 use Illuminate\Database\Eloquent\Collection;
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class SaleServiceTest extends TestCase
 {


### PR DESCRIPTION
## Summary
- ensure service unit tests bootstrap the framework

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68431edb1320832088ecafe3774580c1